### PR TITLE
Clean up Mars ISRU engines

### DIFF
--- a/GameData/RealISRU/Parts/MMParts/Mars_ISRU.cfg
+++ b/GameData/RealISRU/Parts/MMParts/Mars_ISRU.cfg
@@ -96,19 +96,69 @@
 	}
 }
 
-+PART[liquidEngineMini]:FINAL
++PART[liquidEngineMini]
 {
-	@name = MethaneEngine
-	
-	%title = Methane CECE Mini
+	@name = Mars_Methane_1/4
+	%RSSROConfig = True
 
-	@MODULE[ModuleEngineConfigs]
+	!mesh = DELETE
+	!MODEL,*{}
+	MODEL
 	{
+		model = Squad/Parts/Engine/liquidEngine48-7S/model
+		scale = 2.0, 4.1, 2.0
+	}
+    %scale = 1.0
+	%rescaleFactor = 1.0
+	%node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -1.605, 0.0, 0.0, -1.0, 0.0, 2
+	%attachRules = 1,0,1,0,0
+	
+	%maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+	@title = Mars Methane 16.7kN
+	@description = Mars Methane 16.7kN
+	
+	@mass = 0.0525 // quarter that of the methane CECE
+	
+	@MODULE[ModuleEngines*]
+	{
+		%minThrust = 5.55
+		%maxThrust = 16.675
+		
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdMethane
+			@ratio = 0.427
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.573
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 360
+			@key,1 = 1 100
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 0.0525
+		modded = false
+		configuration = CECE-M-1/4
+
 		CONFIG
 		{
-			name = CECE-M-Mini
-			minThrust = 7.4
-			maxThrust = 22.2
+			// thrust based on the CECE, fuel ratio of 3.6:1 from Zubrin paper
+			// and to match the prototype ISRU unit ratios by design
+			name = CECE-M-1/4
+			minThrust = 5.55
+			maxThrust = 16.675
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -122,14 +172,76 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 350
+				key = 0 360
 				key = 1 100
 			}
+			%ullage = True
+			%ignitions = 10
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
 		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 8
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
 	}
 }
 
 /// For a human scale system
+
++PART[Mars_Methane_1/4]
+{
+	@name = Mars_Methane_1
+	@title = Mars Methane 66.7kN
+	@description = Mars Methane 66.7kN
+	
+	@mass = 0.210
+	
+	!MODULE[ModuleEngineConfigs] {}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 0.210
+		modded = false
+		configuration = CECE-M-1
+		CONFIG
+		{
+			name = CECE-M-1
+			minThrust = 22.2
+			maxThrust = 66.7
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdMethane
+				ratio = 0.427
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.573
+			}
+			atmosphereCurve
+			{
+				key = 0 360
+				key = 1 100
+			}
+			%ullage = True
+			%ignitions = 10
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+		}
+	}
+}
 
 +PART[E-RWGS10]
 {
@@ -222,5 +334,46 @@
 	{
 		@amount = 0
 		@maxAmount = 22.7
+	}
+}
+
+// just to fix template
+
++PART[RealISRU_Hex_PSA]
+{
+	%RSSROConfig = True
+
+	@name = sttest3
+	%title = Mars CO2 Intake
+    @manufacturer = Zubrin Enterprises
+    @description = Test Atmo Capture & Fuel Maker
+	
+	@attachRules = 0,1,0,0,0
+	
+	%rescaleFactor = 0.3
+
+    @maxTemp = 2000 // 3500
+	
+	@mass = 0.025 // half mass, other half will be CO2 capture
+	
+	!MODULE[ModuleResourceHarvester],* {}
+	
+	MODULE
+	{
+		name = ModuleResourceHarvester
+		HarvesterType = 2
+		Efficiency = 0.1011
+		ResourceName = CarbonDioxide
+		ConverterName = CO2 Filtration
+		StartActionName = Start Filtering CO2
+		StopActionName = Stop Filtering CO2
+		AutoShutdown = true
+		UseSpecialistBonus = false
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5 // 500W if this works
+		}
 	}
 }


### PR DESCRIPTION
Create them as original stock clones instead of clones of clones. Standardize names. Add gimbal. Engine masses are now relative to the CECE Methane engine mass
