### PR TITLE
Various fixes and QoL changes. See notes.

### DIFF
--- a/GameData/RealISRU/Parts/HexAssembly/HaberBosch.cfg
+++ b/GameData/RealISRU/Parts/HexAssembly/HaberBosch.cfg
@@ -29,7 +29,7 @@ NODE
     subcategory = 0
     title = Haber-Bosch Reactor Assembly
     manufacturer = Dr. Jet's Chop Shop
-    description = (N2 + 3H2 -> NH3)
+    description = (N2 + 3H2 -> NH3)  Includes installation of hydrogen heaters in attached liquid hydrogen tanks.
     
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,0,0,1
@@ -77,6 +77,33 @@ NODE
             DumpExcess = false
         }
     }	
+	// This allows players to carry hydrogen with them in liquid form and heat it up as needed.
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = LH2 Heater
+        StartActionName = Generate Hydrogen Gas
+        StopActionName = Stop H2 Gas Generation
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+
+		INPUT_RESOURCE
+		{
+			name = LqdHydrogen
+			rate = 0.01611621229
+		}
+		INPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.512
+		}
+		OUTPUT_RESOURCE
+		{
+			name = Hydrogen
+			rate = 12.70115285
+		}
+    }
 
 // No animation... yet.
 	

--- a/GameData/RealISRU/Parts/HexAssembly/HaberBosch.cfg
+++ b/GameData/RealISRU/Parts/HexAssembly/HaberBosch.cfg
@@ -110,19 +110,19 @@ NODE
 	
 // Change liters to KSP units please
 	
-	    RESOURCE
+    RESOURCE
     {
         name = Hydrogen
 		amount = 0
 		maxAmount = 50  //liters
 	}
-		RESOURCE
+	RESOURCE
     {
         name = Nitrogen
 		amount = 0
 		maxAmount = 50  //liters
 	}
-	    RESOURCE
+    RESOURCE
     {
         name = Ammonia
 		amount = 0

--- a/GameData/RealISRU/Parts/HexAssembly/elektron.cfg
+++ b/GameData/RealISRU/Parts/HexAssembly/elektron.cfg
@@ -69,13 +69,13 @@ NODE
         {
             ResourceName = Hydrogen
             Ratio = 560.091841255863
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Oxygen
             Ratio = 283.42961251711
-            DumpExcess = false
+            DumpExcess = true
         }
     }
 	MODULE

--- a/GameData/RealISRU/Parts/HexAssembly/fuelcell.cfg
+++ b/GameData/RealISRU/Parts/HexAssembly/fuelcell.cfg
@@ -58,23 +58,23 @@ NODE
         {
             ResourceName = Hydrogen
             Ratio = 560.091841255863
-            DumpExcess = false
         }
         INPUT_RESOURCE
         {
             ResourceName = Oxygen
             Ratio = 283.42961251711
-            DumpExcess = false
         }
         OUTPUT_RESOURCE
         {
             ResourceName = ElectricCharge
             Ratio = 600
+			DumpExcess = True
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Water
             Ratio = 1
+			DumpExcess = True
         }
     }
 	MODULE

--- a/GameData/RealISRU/Parts/HexAssembly/sabatier.cfg
+++ b/GameData/RealISRU/Parts/HexAssembly/sabatier.cfg
@@ -97,17 +97,17 @@ NODE
 
 		INPUT_RESOURCE
 		{
-			name = LqdHydrogen
+			ResourceName = LqdHydrogen
 			rate = 0.01611621229
 		}
 		INPUT_RESOURCE
 		{
-			name = ElectricCharge
+			ResourceName = ElectricCharge
 			rate = 0.512
 		}
 		OUTPUT_RESOURCE
 		{
-			name = Hydrogen
+			ResourceName = Hydrogen
 			rate = 12.70115285
 		}
     }
@@ -117,25 +117,25 @@ NODE
 	
 // Change liters to KSP units please
 	
-	    RESOURCE
+	RESOURCE
     {
         name = Hydrogen
 		amount = 0
 		maxAmount = 55  //liters
 	}
-		RESOURCE
+	RESOURCE
     {
         name = CarbonDioxide
 		amount = 0
 		maxAmount = 100  //liters
 	}
-	    RESOURCE
+	RESOURCE
     {
         name = Water
 		amount = 0
 		maxAmount = 45   //liters
 	}
-	    RESOURCE
+	RESOURCE
     {
         name = Methane
 		amount = 0

--- a/GameData/RealISRU/Parts/HexAssembly/sabatier.cfg
+++ b/GameData/RealISRU/Parts/HexAssembly/sabatier.cfg
@@ -75,13 +75,13 @@ NODE
         {
             ResourceName = Methane
             Ratio = 0.892552187169329
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Water
             Ratio = 0.00143753829366053
-            DumpExcess = false
+            DumpExcess = true
         }
     }	
 

--- a/GameData/RealISRU/Parts/HexAssembly/sabatier.cfg
+++ b/GameData/RealISRU/Parts/HexAssembly/sabatier.cfg
@@ -29,7 +29,7 @@ NODE
     subcategory = 0
     title = Sabatier Reactor Assembly
     manufacturer = Dr. Jet's Chop Shop
-    description = This asssembly includes two Sabatier reactors for high ald low temperature conversion along with thermal exchangers to ensure most energy effective procession. (CO2 + H2 -> CH4 + H2O)
+    description = This asssembly includes two Sabatier reactors for high ald low temperature conversion along with thermal exchangers to ensure most energy effective procession. (CO2 + H2 -> CH4 + H2O)  Includes installation of hydrogen heaters in attached liquid hydrogen tanks.
     
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,0,0,1
@@ -83,7 +83,34 @@ NODE
             Ratio = 0.00143753829366053
             DumpExcess = true
         }
-    }	
+    }
+	// This allows players to carry hydrogen with them in liquid form and heat it up as needed.
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = LH2 Heater
+        StartActionName = Generate Hydrogen Gas
+        StopActionName = Stop H2 Gas Generation
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+
+		INPUT_RESOURCE
+		{
+			name = LqdHydrogen
+			rate = 0.01611621229
+		}
+		INPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.512
+		}
+		OUTPUT_RESOURCE
+		{
+			name = Hydrogen
+			rate = 12.70115285
+		}
+    }
 
 // No animation... yet.
 	

--- a/GameData/RealISRU/Parts/KA_Analyzer/Analyzer_Copies.cfg
+++ b/GameData/RealISRU/Parts/KA_Analyzer/Analyzer_Copies.cfg
@@ -29,13 +29,13 @@
         {
             ResourceName = CarbonMonoxide
             Ratio = 0.894028793456033
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Oxygen
             Ratio = 0.226356067528173
-            DumpExcess = false
+            DumpExcess = true
         }
     }
 }
@@ -71,13 +71,13 @@
         {
             ResourceName = Carbon
             Ratio = 0.000230094546669042
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Hydrogen
             Ratio = 0.902079991900116
-            DumpExcess = false
+            DumpExcess = true
         }
     }
     RESOURCE

--- a/GameData/RealISRU/Parts/KA_Analyzer/KA_Analyzer.cfg
+++ b/GameData/RealISRU/Parts/KA_Analyzer/KA_Analyzer.cfg
@@ -64,13 +64,13 @@ PART
         {
             ResourceName = Hydrogen
             Ratio = 560.091841255863
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Oxygen
             Ratio = 283.42961251711
-            DumpExcess = false
+            DumpExcess = true
         }
     }
 }

--- a/GameData/RealISRU/Parts/KA_Generator_02/Generator_Copies.cfg
+++ b/GameData/RealISRU/Parts/KA_Generator_02/Generator_Copies.cfg
@@ -34,13 +34,13 @@
         {
             ResourceName = CarbonDioxide
             Ratio = 0.906011088153879
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Hydrogen
             Ratio = 0.450295043999461
-            DumpExcess = false
+            DumpExcess = true
         }
     }
     MODULE
@@ -72,13 +72,13 @@
         {
             ResourceName = CarbonMonoxide
             Ratio = 0.894028793456033
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Water
             Ratio = 0.000718769146830266
-            DumpExcess = false
+            DumpExcess = true
         }
     }
 }
@@ -114,13 +114,13 @@
         {
             ResourceName = Carbon
             Ratio = 0.000228190434316876
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Water
             Ratio = 0.00143753829366053
-            DumpExcess = false
+            DumpExcess = true
         }
     }
     RESOURCE

--- a/GameData/RealISRU/Parts/KA_Generator_02/Generator_Copies.cfg
+++ b/GameData/RealISRU/Parts/KA_Generator_02/Generator_Copies.cfg
@@ -87,7 +87,7 @@
 {
     @name = RealISRU_BoschReaction
     @title = Bosch Reactor Unit
-    @description = IN DEVELOPMENT: A small Bosch reaction unit.  <b>CO2 + 2 H2 --> C + 2 H2O</b>
+    @description = IN DEVELOPMENT: A small Bosch reaction unit.  <b>CO2 + 2 H2 --> C + 2 H2O</b> Includes installation of hydrogen heaters in attached liquid hydrogen tanks.
     
     !MODULE[ModuleResourceConverter] {}
     MODULE
@@ -122,6 +122,33 @@
             Ratio = 0.00143753829366053
             DumpExcess = true
         }
+    }
+	// This allows players to carry hydrogen with them in liquid form and heat it up as needed.
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = LH2 Heater
+        StartActionName = Generate Hydrogen Gas
+        StopActionName = Stop H2 Gas Generation
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+
+		INPUT_RESOURCE
+		{
+			name = LqdHydrogen
+			rate = 0.01611621229
+		}
+		INPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.512
+		}
+		OUTPUT_RESOURCE
+		{
+			name = Hydrogen
+			rate = 12.70115285
+		}
     }
     RESOURCE
     {

--- a/GameData/RealISRU/Parts/KA_Generator_02/Generator_Copies.cfg
+++ b/GameData/RealISRU/Parts/KA_Generator_02/Generator_Copies.cfg
@@ -136,18 +136,18 @@
 
 		INPUT_RESOURCE
 		{
-			name = LqdHydrogen
-			rate = 0.01611621229
+			ResourceName = LqdHydrogen
+			Ratio = 0.01611621229
 		}
 		INPUT_RESOURCE
 		{
-			name = ElectricCharge
-			rate = 0.512
+			ResourceName = ElectricCharge
+			Ratio = 0.512
 		}
 		OUTPUT_RESOURCE
 		{
-			name = Hydrogen
-			rate = 12.70115285
+			ResourceName = Hydrogen
+			Ratio = 12.70115285
 		}
     }
     RESOURCE

--- a/GameData/RealISRU/Parts/KA_Generator_02/KA_Generator_02.cfg
+++ b/GameData/RealISRU/Parts/KA_Generator_02/KA_Generator_02.cfg
@@ -71,13 +71,13 @@ PART
         {
             ResourceName = Methane
             Ratio = 0.892552187169329
-            DumpExcess = false
+            DumpExcess = True
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Water
             Ratio = 0.00143753829366053
-            DumpExcess = false
+            DumpExcess = true
         }
     }
 }

--- a/GameData/RealISRU/Parts/KA_Generator_02/KA_Generator_02.cfg
+++ b/GameData/RealISRU/Parts/KA_Generator_02/KA_Generator_02.cfg
@@ -93,18 +93,18 @@ PART
 
 		INPUT_RESOURCE
 		{
-			name = LqdHydrogen
-			rate = 0.01611621229
+			ResourceName = LqdHydrogen
+			Ratio = 0.01611621229
 		}
 		INPUT_RESOURCE
 		{
-			name = ElectricCharge
-			rate = 0.512
+			ResourceName = ElectricCharge
+			Ratio = 0.512
 		}
 		OUTPUT_RESOURCE
 		{
-			name = Hydrogen
-			rate = 12.70115285
+			ResourceName = Hydrogen
+			Ratio = 12.70115285
 		}
     }
 }

--- a/GameData/RealISRU/Parts/KA_Generator_02/KA_Generator_02.cfg
+++ b/GameData/RealISRU/Parts/KA_Generator_02/KA_Generator_02.cfg
@@ -25,7 +25,7 @@ PART
     subcategory = 0
     title = Sabatier Reactor Unit
     manufacturer = Various
-    description = IN DEVELOPMENT: A small Sabatier reactor unit.  <b>CO2 + 4 H2 --> CH4 + 2 H2O</b>
+    description = IN DEVELOPMENT: A small Sabatier reactor unit.  <b>CO2 + 4 H2 --> CH4 + 2 H2O</b> Includes installation of hydrogen heaters in attached liquid hydrogen tanks.
     
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,0,1,0
@@ -79,5 +79,32 @@ PART
             Ratio = 0.00143753829366053
             DumpExcess = true
         }
+    }
+	// This allows players to carry hydrogen with them in liquid form and heat it up as needed.
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = LH2 Heater
+        StartActionName = Generate Hydrogen Gas
+        StopActionName = Stop H2 Gas Generation
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+
+		INPUT_RESOURCE
+		{
+			name = LqdHydrogen
+			rate = 0.01611621229
+		}
+		INPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.512
+		}
+		OUTPUT_RESOURCE
+		{
+			name = Hydrogen
+			rate = 12.70115285
+		}
     }
 }

--- a/GameData/RealISRU/Parts/MMParts/AtmosphericIntake.cfg
+++ b/GameData/RealISRU/Parts/MMParts/AtmosphericIntake.cfg
@@ -157,7 +157,7 @@
     !MODEL {}
     MODEL
     {
-            model = Squad/Parts/Aero/engineNacelle/Nacelle2
+            model = Squad/Parts/Structural/mk1Parts/Nacelle1
             scale = 1.6, 0.2, 1.6
     }
 

--- a/GameData/RealISRU/Parts/MMParts/AtmosphericIntake.cfg
+++ b/GameData/RealISRU/Parts/MMParts/AtmosphericIntake.cfg
@@ -1,6 +1,8 @@
 +PART[CircularIntake]
 {
     @name = RealISRU_AtmosphericIntakeSmall
+	attach_node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+	@attachRules = 1,1,1,0,0
     @title = Small Atmospheric ISRU Intake
 	@manufacturer = Various
 	@description = An atmospheric intake and filter designed for use deep within an atmosphere, rather than in orbit.

--- a/GameData/RealISRU/Parts/MMParts/ISRU.cfg
+++ b/GameData/RealISRU/Parts/MMParts/ISRU.cfg
@@ -39,7 +39,7 @@
         {
             ResourceName = Ammonia
             Ratio = 1.78023691114274
-            DumpExcess = false
+            DumpExcess = true
         }
     }
 }
@@ -80,13 +80,13 @@
         {
             ResourceName = Water
             Ratio = 0.00109814825506429
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = NTO
             Ratio = 0.00128934889724417
-            DumpExcess = false
+            DumpExcess = true
         }
     }
 }
@@ -129,13 +129,13 @@
         {
             ResourceName = Kerosene
             Ratio = 0.000667013128209099
-            DumpExcess = false
+            DumpExcess = true
         }
         OUTPUT_RESOURCE
         {
             ResourceName = Water
             Ratio = 0.000694171868542514
-            DumpExcess = false
+            DumpExcess = true
         }
     }
 }

--- a/GameData/RealISRU/Parts/MMParts/Mars_ISRU.cfg
+++ b/GameData/RealISRU/Parts/MMParts/Mars_ISRU.cfg
@@ -517,7 +517,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Plutonium-238
-			Ratio = 0.00000018776
+			Ratio = 0.0000000018776
 		}
 
 		OUTPUT_RESOURCE
@@ -530,7 +530,7 @@
 		OUTPUT_RESOURCE
 		{
 			ResourceName = DepletedFuel
-			Ratio = 1.87756-7
+			Ratio = 0.0000000018776
 			DumpExcess = True // probably superfluous as P238 consumption run out at the same time as room for DF runs out.
 		}
 	}

--- a/GameData/RealISRU/Parts/MMParts/Mars_ISRU.cfg
+++ b/GameData/RealISRU/Parts/MMParts/Mars_ISRU.cfg
@@ -1,6 +1,6 @@
 // Mars ISRU Engines. CECE-Methane based. 3.6:1 F:O ratio.
 
-+PART[liquidEngineMini]:FOR[RealISRU]:BEFORE[RealismOverhaul]
++PART[liquidEngineMini]:BEFORE[RealismOverhaul]
 {
 	@name = Mars_Methane_1/4
 	@title = Mars Methane 16.7kN
@@ -311,7 +311,7 @@
 	@mass = 0.021 // Sum of chem synth, controls, lines, misc.
 	
 	!RESOURCE[Carbon] {}
-    	!MODULE[ModuleResourceConverter],* {}
+    !MODULE[ModuleResourceConverter],* {}
 	!RESOURCE[ElectricCharge] {}
 
 	MODULE
@@ -492,13 +492,13 @@
 	@name = ISRU_RTG_100
 	@title = ISRU_RTG_100
 	@description = ISRU_RTG_100
-    	@manufacturer = Zubrin Enterprises
+    @manufacturer = Zubrin Enterprises
 	%RSSROConfig = True
 	
 	@mass = 0.2
 	
 	!MODULE[ModuleResourceConverter] {}
-	
+	!MODULE[ModuleGenerator]{}
 	MODULE
 	{
 		name = TacGenericConverter
@@ -524,26 +524,28 @@
 		{
 			ResourceName = ElectricCharge
 			Ratio = 3.6
-			DumpExcess = False
+			DumpExcess = True // RTG keeps on running regardless of whether it has room for EC or not
 		}
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = DepletedFuel
 			Ratio = 1.87756-7
-			DumpExcess = True
+			DumpExcess = True // probably superfluous as P238 consumption run out at the same time as room for DF runs out.
 		}
 	}
 	
-	@RESOURCE[Plutonium-238]
+	RESOURCE
 	{
-		@amount = 25.9
-		@maxAmount = 25.9
+		name = Plutonium-238
+		amount = 25.9
+		maxAmount = 25.9
 	}
-	@RESOURCE[DepletedFuel]
+	RESOURCE
 	{
-		@amount = 0
-		@maxAmount = 25.9
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 25.9
 	}
 }
 
@@ -558,6 +560,7 @@
     	@mass = 0.6 // random test mass
 	
 	!MODULE[ModuleResourceConverter] {}
+	!MODULE[ModuleGenerator]{}
 	
 	MODULE
 	{
@@ -581,22 +584,25 @@
 		{
 			ResourceName = ElectricCharge
 			Ratio = 235
+			DumpExcess = true // RTG cannot be throttled and will output no matter if there is room for EC or not
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = DepletedFuel
-			Ratio = 1.6428e-6
+			Ratio = 1.6428e-6 
 		}
 	}
 	
-	@RESOURCE[Plutonium-238]
+	RESOURCE
 	{
-		@amount = 22.7
-		@maxAmount = 22.7
+		name = Plutonium-238
+		amount = 25.9
+		maxAmount = 25.9
 	}
-	@RESOURCE[DepletedFuel]
+	RESOURCE
 	{
-		@amount = 0
-		@maxAmount = 22.7
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 25.9
 	}
 }

--- a/GameData/RealISRU/Parts/MMParts/Refrigerator.cfg
+++ b/GameData/RealISRU/Parts/MMParts/Refrigerator.cfg
@@ -1,148 +1,275 @@
 +PART[FuelCellArray]
 {
-    @name = RealISRU_LiquefactionArray
+	@name = RealISRU_LiquefactionArray
 
-    !MODEL {}
-    MODEL
-    {
-        model = Squad/Parts/Resources/FuelCell/FuelCellArray
-        scale = 1.0, 1.0, 1.0
-    }
+	!MODEL {}
+	MODEL
+	{
+		model = Squad/Parts/Resources/FuelCell/FuelCellArray
+		scale = 1.0, 1.0, 1.0
+	}
 	MODEL
 	{
 		model = Squad/Parts/Resources/SurfaceScanner/SurfaceScanner
 		scale = 1.0, 1.0, 1.0
 		position = -0.0863, 0.2941, 0.0
-        rotation = 0, 90, 0
+		rotation = 0, 90, 0
 	}
 	MODEL
 	{
 		model = Squad/Parts/Science/sensorAccelerometer/model
 		scale = 1.0, 1.0, 1.0
 		position = -0.06134, 0.72369, 0.0
-        rotation = 0, 90, 0
+		rotation = 0, 90, 0
 	}
 	MODEL
 	{
 		model = Squad/Parts/Science/sensorAccelerometer/model
 		scale = 1.0, 1.0, 1.0
 		position = -0.06354, -0.10946, 0.0
-        rotation = 0, 90, 0
+		rotation = 0, 90, 0
 	}
 
-    @node_attach = .05, 0, 0, 1, 0, 0, 0
+	@node_attach = .05, 0, 0, 1, 0, 0, 0
 
-    @TechRequired = specializedElectrics
-    @entryCost = 13500
-    @cost = 4500
-    @category = Utility
-    @subcategory = 0
-    @title = Liquefaction Array
-    @manufacturer = Various
-    @description = Uses a combination of active cooling and pressurization turbines to convert gasses into liquids.
-    @attachRules = 0,1,0,0,0
+	@TechRequired = specializedElectrics
+	@entryCost = 13500
+	@cost = 4500
+	@category = Utility
+	@subcategory = 0
+	@title = Liquefaction Array
+	@manufacturer = Various
+	@description = Uses a combination of active cooling and pressurization turbines to convert gasses into liquids.
+	@attachRules = 0,1,0,0,0
 
-    // --- standard part parameters ---
-    @mass = 0.75
-    @dragModelType = default
-    @maximum_drag = 0.2
-    @minimum_drag = 0.2
-    @angularDrag = 2
-    @crashTolerance = 7
-    @maxTemp = 2000 // = 3000
+	// --- standard part parameters ---
+	@mass = 0.75
+	@dragModelType = default
+	@maximum_drag = 0.2
+	@minimum_drag = 0.2
+	@angularDrag = 2
+	@crashTolerance = 7
+	@maxTemp = 2000 // = 3000
 
 	!MODULE[ModuleResourceConverter] {}
 	!RESOURCE[ElectricCharge] {}
 
-    MODULE
-    {
-        name = ModuleResourceConverter
-        ConverterName = Liquefy Oxygen
-        StartActionName = Start Liquefying Oxygen
-        StopActionName = Stop Liquefying Oxygen
-        AutoShutdown = false
-        GeneratesHeat = true
-        UseSpecialistBonus = false
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Liquefy Oxygen
+		StartActionName = Start Liquefying Oxygen
+		StopActionName = Stop Liquefying Oxygen
+		AutoShutdown = false
+		GeneratesHeat = true
+		UseSpecialistBonus = false
 
-        INPUT_RESOURCE
-        {
-            ResourceName = Oxygen
-            Ratio = 1
-        }
-        OUTPUT_RESOURCE
-        {
-            ResourceName = LqdOxygen
-            Ratio = 0.00247157800561483
-            DumpExcess = false
-        }
-    }
+		INPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 1.5021884
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LqdOxygen
+			Ratio = 0.001856341493
+			DumpExcess = false
+		}
+		ThermalEfficiency
+		{
+			key = 100 1
+			key = 200 0.3333333333
+			key = 300 0.2
+			key = 400 0.1428571429
+			key = 500 0.1111111111
+			key = 600 0.09090909091
+			key = 700 0.07692307692
+			key = 800 0.06666666667
+			key = 900 0.05882352941
+			key = 1000 0.05263157895
+			key = 1100 0.04761904762
+			key = 1200 0.04347826087
+			key = 1300 0.04
+			key = 1400 0.03703703704
+			key = 1500 0.03448275862
+			key = 1600 0.03225806452
+			key = 1700 0.0303030303
+			key = 1800 0.02857142857
+			key = 1900 0.02702702703
+			key = 10000 0.005025125628
+		}
+		TemperatureModifier
+		{
+			key = 0 0.8591851322
+		}
+	}
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Liquefy Hydrogen
+		StartActionName = Start Liquefying Hydrogen
+		StopActionName = Stop Liquefying Hydrogen
+		AutoShutdown = false
+		GeneratesHeat = true
+		UseSpecialistBonus = false
 
-    MODULE
-    {
-        name = ModuleResourceConverter
-        ConverterName = Liquefy Hydrogen
-        StartActionName = Start Liquefying Hydrogen
-        StopActionName = Stop Liquefying Hydrogen
-        AutoShutdown = false
-        GeneratesHeat = true
-        UseSpecialistBonus = false
+		INPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 2.534364569
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LqdHydrogen
+			Ratio = 0.003215799221
+			DumpExcess = false
+		}
+		ThermalEfficiency
+		{
+			key = 100 1
+			key = 200 0.3333333333
+			key = 300 0.2
+			key = 400 0.1428571429
+			key = 500 0.1111111111
+			key = 600 0.09090909091
+			key = 700 0.07692307692
+			key = 800 0.06666666667
+			key = 900 0.05882352941
+			key = 1000 0.05263157895
+			key = 1100 0.04761904762
+			key = 1200 0.04347826087
+			key = 1300 0.04
+			key = 1400 0.03703703704
+			key = 1500 0.03448275862
+			key = 1600 0.03225806452
+			key = 1700 0.0303030303
+			key = 1800 0.02857142857
+			key = 1900 0.02702702703
+			key = 10000 0.005025125628
+		}
+		TemperatureModifier
+		{
+			key = 0 0.1440057173
+		}
+	}
 
-        INPUT_RESOURCE
-        {
-            ResourceName = Hydrogen
-            Ratio = 1
-        }
-        OUTPUT_RESOURCE
-        {
-            ResourceName = LqdHydrogen
-            Ratio = 0.00253785653674714
-            DumpExcess = false
-        }
-    }
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Liquefy Ammonia
+		StartActionName = Start Liquefying Ammonia
+		StopActionName = Stop Liquefying Ammonia
+		AutoShutdown = false
+		GeneratesHeat = true
+		UseSpecialistBonus = false
 
-    MODULE
-    {
-        name = ModuleResourceConverter
-        ConverterName = Liquefy Ammonia
-        StartActionName = Start Liquefying Ammonia
-        StopActionName = Stop Liquefying Ammonia
-        AutoShutdown = false
-        GeneratesHeat = true
-        UseSpecialistBonus = false
+		INPUT_RESOURCE
+		{
+			ResourceName = Ammonia
+			Ratio = 29.2358536
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LqdAmmonia
+			Ratio = 0.03202160863
+			DumpExcess = false
+		}
+		ThermalEfficiency
+		{
+			key = 100 1
+			key = 200 0.3333333333
+			key = 300 0.2
+			key = 400 0.1428571429
+			key = 500 0.1111111111
+			key = 600 0.09090909091
+			key = 700 0.07692307692
+			key = 800 0.06666666667
+			key = 900 0.05882352941
+			key = 1000 0.05263157895
+			key = 1100 0.04761904762
+			key = 1200 0.04347826087
+			key = 1300 0.04
+			key = 1400 0.03703703704
+			key = 1500 0.03448275862
+			key = 1600 0.03225806452
+			key = 1700 0.0303030303
+			key = 1800 0.02857142857
+			key = 1900 0.02702702703
+			key = 10000 0.005025125628
+		}
+		TemperatureModifier
+		{
+			key = 0 7.623095429
+		}
+	}
 
-        INPUT_RESOURCE
-        {
-            ResourceName = Ammonia
-            Ratio = 1
-        }
-        OUTPUT_RESOURCE
-        {
-            ResourceName = LqdAmmonia
-            Ratio = 0.00109525470243689
-            DumpExcess = false
-        }
-    }
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Liquefy Methane
+		StartActionName = Start Liquefying Methane
+		StopActionName = Stop Liquefying Methane
+		AutoShutdown = false
+		GeneratesHeat = true
+		UseSpecialistBonus = false
 
-    MODULE
-    {
-        name = ModuleResourceConverter
-        ConverterName = Liquefy Methane
-        StartActionName = Start Liquefying Methane
-        StopActionName = Stop Liquefying Methane
-        AutoShutdown = false
-        GeneratesHeat = true
-        UseSpecialistBonus = false
-
-        INPUT_RESOURCE
-        {
-            ResourceName = Methane
-            Ratio = 1
-        }
-        OUTPUT_RESOURCE
-        {
-            ResourceName = LqdMethane
-            Ratio = 0.00168489923601513
-            DumpExcess = false
-        }
-    }
+		INPUT_RESOURCE
+		{
+			ResourceName = Methane
+			Ratio = 7.222546275
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LqdMethane
+			Ratio = 0.01216739663
+			DumpExcess = false
+		}
+		ThermalEfficiency
+		{
+			key = 100 1
+			key = 200 0.3333333333
+			key = 300 0.2
+			key = 400 0.1428571429
+			key = 500 0.1111111111
+			key = 600 0.09090909091
+			key = 700 0.07692307692
+			key = 800 0.06666666667
+			key = 900 0.05882352941
+			key = 1000 0.05263157895
+			key = 1100 0.04761904762
+			key = 1200 0.04347826087
+			key = 1300 0.04
+			key = 1400 0.03703703704
+			key = 1500 0.03448275862
+			key = 1600 0.03225806452
+			key = 1700 0.0303030303
+			key = 1800 0.02857142857
+			key = 1900 0.02702702703
+			key = 10000 0.005025125628
+		}
+		TemperatureModifier
+		{
+			key = 0 1.182179793
+		}
+	}
 }

--- a/GameData/RealISRU/Parts/MMParts/Refrigerator.cfg
+++ b/GameData/RealISRU/Parts/MMParts/Refrigerator.cfg
@@ -82,30 +82,20 @@
 		}
 		ThermalEfficiency
 		{
-			key = 100 1
-			key = 200 0.3333333333
-			key = 300 0.2
-			key = 400 0.1428571429
-			key = 500 0.1111111111
-			key = 600 0.09090909091
-			key = 700 0.07692307692
-			key = 800 0.06666666667
-			key = 900 0.05882352941
-			key = 1000 0.05263157895
-			key = 1100 0.04761904762
-			key = 1200 0.04347826087
-			key = 1300 0.04
-			key = 1400 0.03703703704
-			key = 1500 0.03448275862
-			key = 1600 0.03225806452
-			key = 1700 0.0303030303
-			key = 1800 0.02857142857
-			key = 1900 0.02702702703
-			key = 10000 0.005025125628
+			key = 250 1
+			key = 350 0.3333333333
+			key = 450 0.2
+			key = 550 0.1428571429
+			key = 650 0.1111111111
+			key = 750 0.09090909091
+			key = 850 0.07692307692
+			key = 950 0.06666666667
+			key = 1000 0.05882352941
 		}
 		TemperatureModifier
 		{
-			key = 0 0.8591851322
+			key = 0 10.85918513
+			key = 100 10.85918513
 		}
 	}
 	MODULE
@@ -136,30 +126,20 @@
 		}
 		ThermalEfficiency
 		{
-			key = 100 1
-			key = 200 0.3333333333
-			key = 300 0.2
-			key = 400 0.1428571429
-			key = 500 0.1111111111
-			key = 600 0.09090909091
-			key = 700 0.07692307692
-			key = 800 0.06666666667
-			key = 900 0.05882352941
-			key = 1000 0.05263157895
-			key = 1100 0.04761904762
-			key = 1200 0.04347826087
-			key = 1300 0.04
-			key = 1400 0.03703703704
-			key = 1500 0.03448275862
-			key = 1600 0.03225806452
-			key = 1700 0.0303030303
-			key = 1800 0.02857142857
-			key = 1900 0.02702702703
-			key = 10000 0.005025125628
+			key = 250 1
+			key = 350 0.3333333333
+			key = 450 0.2
+			key = 550 0.1428571429
+			key = 650 0.1111111111
+			key = 750 0.09090909091
+			key = 850 0.07692307692
+			key = 950 0.06666666667
+			key = 1000 0.05882352941
 		}
 		TemperatureModifier
 		{
-			key = 0 0.1440057173
+			key = 0 10.14400572
+			key = 100 10.14400572
 		}
 	}
 
@@ -191,30 +171,20 @@
 		}
 		ThermalEfficiency
 		{
-			key = 100 1
-			key = 200 0.3333333333
-			key = 300 0.2
-			key = 400 0.1428571429
-			key = 500 0.1111111111
-			key = 600 0.09090909091
-			key = 700 0.07692307692
-			key = 800 0.06666666667
-			key = 900 0.05882352941
-			key = 1000 0.05263157895
-			key = 1100 0.04761904762
-			key = 1200 0.04347826087
-			key = 1300 0.04
-			key = 1400 0.03703703704
-			key = 1500 0.03448275862
-			key = 1600 0.03225806452
-			key = 1700 0.0303030303
-			key = 1800 0.02857142857
-			key = 1900 0.02702702703
-			key = 10000 0.005025125628
+			key = 250 1
+			key = 350 0.3333333333
+			key = 450 0.2
+			key = 550 0.1428571429
+			key = 650 0.1111111111
+			key = 750 0.09090909091
+			key = 850 0.07692307692
+			key = 950 0.06666666667
+			key = 1000 0.05882352941
 		}
 		TemperatureModifier
 		{
-			key = 0 7.623095429
+			key = 0 17.62309543
+			key = 100 17.62309543
 		}
 	}
 
@@ -246,30 +216,49 @@
 		}
 		ThermalEfficiency
 		{
-			key = 100 1
-			key = 200 0.3333333333
-			key = 300 0.2
-			key = 400 0.1428571429
-			key = 500 0.1111111111
-			key = 600 0.09090909091
-			key = 700 0.07692307692
-			key = 800 0.06666666667
-			key = 900 0.05882352941
-			key = 1000 0.05263157895
-			key = 1100 0.04761904762
-			key = 1200 0.04347826087
-			key = 1300 0.04
-			key = 1400 0.03703703704
-			key = 1500 0.03448275862
-			key = 1600 0.03225806452
-			key = 1700 0.0303030303
-			key = 1800 0.02857142857
-			key = 1900 0.02702702703
-			key = 10000 0.005025125628
+			
+			key = 250 1
+			key = 350 0.3333333333
+			key = 450 0.2
+			key = 550 0.1428571429
+			key = 650 0.1111111111
+			key = 750 0.09090909091
+			key = 850 0.07692307692
+			key = 950 0.06666666667
+			key = 1000 0.05882352941
 		}
 		TemperatureModifier
 		{
-			key = 0 1.182179793
+			key = 0 11.18217979
+			key = 100 11.18217979
 		}
 	}
+	MODULE
+	{
+		name = ModuleCoreHeat
+		CoreTempGoal = 250
+		CoreToPartRatio = 0.1
+		CoreTempGoalAdjustment = 0
+		CoreEnergyMultiplier = 0.1
+		
+		// these two control heat gain/loss to part/core
+		// when core energy > part energy
+		HeatRadiantMultiplier = 0 // this scales part energy gain
+		CoolantTransferMultiplier = 0 // this scales core energy loss
+		
+		// these two control heat loss/gain to part/core
+		// when core energy < part energy
+		CoolingRadiantMultiplier = 0.1 // this scales part energy loss
+		HeatTransferMultiplier = 0.1 // this scales core energy gain
+		
+		radiatorCoolingFactor = 1
+		radiatorHeatingFactor = 1
+		MaxCalculationWarp = 1000
+		CoreShutdownTemp = 4000
+		MaxCoolant = 30000
+	}
+	MODULE
+	{
+		name = ModuleOverheatDisplay
+	}		
 }

--- a/GameData/RealISRU/Parts/scienceDrill/part.cfg
+++ b/GameData/RealISRU/Parts/scienceDrill/part.cfg
@@ -57,7 +57,7 @@ PART
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 10
+			Ratio = 2
 		}
 	}
 
@@ -131,5 +131,71 @@ PART
 		deployAnimationName = Deploy
 		activeAnimationName = Deploy0
 		moduleType = Drill
+	}
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Water Extractor
+		StartActionName = Extract H2O from Hydrates
+		StopActionName = Stop Extraction [H2O]
+		AutoShutdown = true
+		GeneratesHeat = true
+		DefaultShutoffTemp = .8
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 750 50000
+			key = 1000 10000
+			key = 1250 500
+			key = 2000 50
+			key = 4000 0
+		}
+		ThermalEfficiency
+		{
+			key = 0 0 0 0
+			key = 500 0.1 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.1 0 0
+			key = 3000 0 0 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Hydrates
+			Ratio = 1
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 5
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			// totally pulled this out of my ass on the assumption maybe 33% of the Hydrates were H2O by mass?
+			// changed it to 10%
+			Ratio = 0.15
+			DumpExcess = false
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+	}
+	RESOURCE
+	{
+		name = Hydrates
+		amount = 0
+		maxAmount = 1
+	}
+	RESOURCE
+	{
+		name = Water
+		amount = 0
+		maxAmount = 1
 	}
 }


### PR DESCRIPTION
* Changed DumpExcess to true for certain resources. Specifically for converters where the resource was not the sole primary product. For instance, it doesn't make a lot of sense for Sabatier reactors to shutdown production of methane just because there's no tankage available to dump water. You might NEED that methane or your ascent vehicle isn't going to ascend...
* Changed production ratios on liquefaction array. Added thermal efficiency curve roughly based on % of Carnot of 20% - this was a one size fits all but each converter should get its own curve but that isn't practical unless this is split into multiple parts: The operating temperature for all of the converters needs to be different but it can't be because you can only have one core heat module per part.
* Added a LH2 heater (converter) to any part that requires hydrogen gas. This allows the player to bring liquid hydrogen and convert it to gas as needed.
* Made small atmospheric intake surface attachable.
* Slowed rate of Pu-238 consumption as 1% per DAY is too fast.
* Increased target goal temp of liquefier to 250. This is technically too high for something involving cryogenic processes but stock Core Heat will not push heat out to radiators unless the core temperature is higher than part internal temperature even if it is higher than the target temp.
* Scaled thermal efficiencies to match the new target temp. So basically the liquefier is producing heat that must be gotten rid of to maintain efficiency. The efficiency is based on actual cryocooler % of Carnot equations and is about as reasonably accurate as we can make it with what we have to work with.
* The ice/hydrate drill now has small sump tanks for hydrates/water.
* The hydrate drill also has a water extractor now which extracts 10% of the hydrate's mass as water. (TODO: Is this too high? Too low? Must verify this)
* Note about the drill. Whether overly optimistic or not, NASA studies have concluded that 33kg of water per day could possibly be gotten from the Martian regolith which is close to what I get with two drills when the water conversion rate was set to 33% of Hydrate mass.... currently I've set it to 10% so increasing drill quantity can still get you there.